### PR TITLE
feat: transition plot single point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
+.DS_STORE
 __pycache__
 *.tgz
 Chart.lock
 .env.*
 .env
-bragg_data
-transition_data
-next_temperature_data
+bragg_volume
 scientist_cloud_volume
+state

--- a/Dockerfile.dashboard
+++ b/Dockerfile.dashboard
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
 
 COPY environment.yaml ./environment.yaml
 COPY dashboard.py ./dashboard.py
+COPY constants.py ./constants.py
 COPY load_gsas.py ./load_gsas.py
 
 RUN conda env create -f ./environment.yaml && \

--- a/Dockerfile.dashboard_service
+++ b/Dockerfile.dashboard_service
@@ -3,6 +3,7 @@ FROM python:3.10-slim
 
 WORKDIR /usr/src/dashboard_service
 COPY dashboard_service.py ./dashboard_service.py
+COPY constants.py ./constants.py
 COPY config_service.yaml ./config_service.yaml
 
 RUN python -m pip install intersect-sdk[amqp]

--- a/Dockerfile.storage_service
+++ b/Dockerfile.storage_service
@@ -3,6 +3,7 @@ FROM python:3.10-slim
 
 WORKDIR /usr/src/storage_service
 COPY storage_service.py ./storage_service.py
+COPY constants.py ./constants.py
 
 RUN python -m pip install python-dotenv boto3==1.35.99
 

--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ undeploy:
 	@docker compose down
 
 rmvolumes:
-	@docker volume rm nsdf-intersect_intersect_bragg_data nsdf-intersect_intersect_next_temperature_data nsdf-intersect_intersect_scientist_cloud_volume nsdf-intersect_intersect_transition_data nsdf-intersect_intersect_retry_volume
+	@docker volume rm nsdf-intersect_intersect_bragg_volume nsdf-intersect_intersect_state nsdf-intersect_intersect_scientist_cloud_volume

--- a/compose_local.yaml
+++ b/compose_local.yaml
@@ -37,10 +37,9 @@ services:
       start_period: 10s
       timeout: 10s
     volumes:
-      - intersect_bragg_data:/usr/src/dashboard/bragg_data/
-      - intersect_transition_data:/usr/src/dashboard/transition_data/
-      - intersect_next_temperature_data:/usr/src/dashboard/next_temperature_data/
+      - intersect_bragg_volume:/usr/src/dashboard/bragg_volume/
       - intersect_scientist_cloud_volume:/usr/src/dashboard/scientist_cloud_volume
+      - intersect_state:/usr/src/dashboard/state/
   dashboard_service:
     image: "intersect-service:latest"
     ports:
@@ -49,13 +48,10 @@ services:
       broker:
         condition: service_healthy
     volumes:
-      - intersect_bragg_data:/usr/src/dashboard_service/bragg_data/
-      - intersect_transition_data:/usr/src/dashboard_service/transition_data/
-      - intersect_next_temperature_data:/usr/src/dashboard_service/next_temperature_data/
+      - intersect_bragg_volume:/usr/src/dashboard_service/bragg_volume/
       - intersect_scientist_cloud_volume:/usr/src/dashboard_service/scientist_cloud_volume
+      - intersect_state:/usr/src/dashboard_service/state/
 volumes:
-  intersect_bragg_data:
-  intersect_transition_data:
-  intersect_next_temperature_data:
+  intersect_bragg_volume:
+  intersect_state:
   intersect_scientist_cloud_volume:
-  intersect_retry_volume:

--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,42 @@
+###############################
+########## STATELESS ##########
+###############################
+
+BRAGG_VOLUME = "bragg_volume"  # scanned by dashboard (bragg plot)
+
+##############################
+########## STATEFUL ##########
+##############################
+
+# VOLUMES
+STATE_VOLUME = "state"  # scanned by dashboard (transition, next temperature)
+SCIENTIST_CLOUD_VOLUME = "scientist_cloud_volume"  # scanned by storage service
+
+# FILES
+TRANSITION_DATA_FILE = "transition_data.txt"
+ANDIE_DATA_FILE = "andie_data.txt"
+RETRY_FILE = "retry.txt"
+
+############################
+########## CONFIG ##########
+############################
+
+# SCIENTIST_CLOUD
+BUCKET_PATH = "utk"
+BRAGG_PATH = "bragg_data"
+TRANSITION_DATA_PATH = "transition_data"
+NEXT_TEMPERATURE_DATA_PATH = "andie_data"
+
+# SCAN PERIODS
+BRAGG_SCAN_PERIOD = 2
+TRANSITION_SCAN_PERIOD = 2
+STORAGE_SCAN_PERIOD = 30
+SELECT_SCAN_PERIOD = 45
+
+# DASHBOARD
+MAX_BANKS = 6
+
+# PLOTS
+BRAGG = "BRAGG"
+TRANSITION = "TRANSITION"
+ANDIE = "ANDIE"


### PR DESCRIPTION
This is the stateful alternative to the existing stateless transition plot. The following implementation uses transition_data.txt for the transition plot and andie_data.txt for the next temperature trace.

- The dashboard service adds the record received along with an id to the corresponding file (transition_data.txt for get_transition_data_single, and andie.txt for get_next_temperature)
- The dashboard implements an id check by extracting the last record received from the file, if the id is not the current id, the plot is updated.
- For the next temperature, we look at the last record for the newest prediction to be plotted as the ANDiE next temperature trace in the transition plot.

Current order of updates in the dashboard
`check_new_bragg_data` (2s)
`check_new_transition_data` --> `check_new_next_temperature_data`(2s)
`select_list` for stateful plot (45s)

#10 