### PR TITLE
Removes hard-coded hierarchy in favor of config file read-in

### DIFF
--- a/dashboard_service.py
+++ b/dashboard_service.py
@@ -248,13 +248,6 @@ def dashboard_service():
         from_config_file = yaml.safe_load(f)
 
     config = IntersectServiceConfig(
-        hierarchy=HierarchyConfig(
-            organization="nsdf-organization",
-            facility="nsdf-facility",
-            system="nsdf-system",
-            subsystem="nsdf-subsystem",
-            service="nsdf-dashboard-service",
-        ),
         **from_config_file,
     )
 


### PR DESCRIPTION
Work includes:
  - simple hotfix to remove the hierarchy hard-coded in favor to add it via a config file instead.

Example:
```
brokers:
    - host: XX.XXX.XXX.XX
      username: CHANGEME
      password: CHANGEME
      port: 1883
      protocol: mqtt3.1.1

hierarchy:
    organization: nsdf
    facility: cloud
    system: diffraction
    subsystem: dashboard
    service: dashboard-service

```