### PR TITLE
fix: pin bitnami rabbitmq image

### DIFF
--- a/deployment/chart/values.yaml
+++ b/deployment/chart/values.yaml
@@ -3,12 +3,11 @@
 ######################
 # anchors are just a useful feature so you don't repeat yourself in the config file
 
-
 .anchors:
   # proxy
   proxy:
     systemName: &proxy-systemName "nsdf.cloud.diffraction."
-    log_level: &proxy-loglevel "debug"  # set to "debug" if you want extremely verbose output, including of the messages themselves
+    log_level: &proxy-loglevel "debug" # set to "debug" if you want extremely verbose output, including of the messages themselves
 
     server:
       serverUsername: &proxy-serverUsername "proxy_username"
@@ -58,7 +57,9 @@ intersect:
           secretKey: *messageBroker-passwordKey
 
   intersect-message-broker-1:
-    image: 
+    image:
+      repository: bitnamilegacy/rabbitmq
+      tag: 3.13.7-debian-12-r2
       debug: true
     auth:
       username: *messageBroker-username
@@ -84,7 +85,7 @@ intersect:
     livenessProbe:
       enabled: false
     readinessProbe:
-      enabled: false  
+      enabled: false
     resources:
       requests:
         memory: "2Gi"
@@ -98,19 +99,19 @@ intersect:
         # ephemeral-storage: "4Gi"
     # need to override extraConfiguration because we need to set a management path prefix
     #extraConfiguration: |-
-      #default_vhost = /
-      #{{- if .Values.resources.limits.storage }}
-      #disk_free_limit.absolute = {{ .Values.resources.limits.storage }}
-      #{{- else }}
-      #disk_free_limit.relative = 0.4
-      #{{- end }}
-      #{{- if .Values.resources.requests.cpu }}
-      #delegate_count = {{ .Values.resources.requests.cpu }}
-      #{{- end }}
-      #mqtt.max_session_expiry_interval_seconds = infinity
-      # set this to the maximum allowed by rabbitmq - https://www.rabbitmq.com/docs/configure#config-items
-      #max_message_size = 536870912
-      #management.path_prefix = /messages
+    #default_vhost = /
+    #{{- if .Values.resources.limits.storage }}
+    #disk_free_limit.absolute = {{ .Values.resources.limits.storage }}
+    #{{- else }}
+    #disk_free_limit.relative = 0.4
+    #{{- end }}
+    #{{- if .Values.resources.requests.cpu }}
+    #delegate_count = {{ .Values.resources.requests.cpu }}
+    #{{- end }}
+    #mqtt.max_session_expiry_interval_seconds = infinity
+    # set this to the maximum allowed by rabbitmq - https://www.rabbitmq.com/docs/configure#config-items
+    #max_message_size = 536870912
+    #management.path_prefix = /messages
 
   intersect-storage-1:
     # we shouldn't need MINIO for this deployment


### PR DESCRIPTION
This PR addresses the change of bitnami images due to the new [bitnami secure images](https://hub.docker.com/r/bitnami/rabbitmq#%EF%B8%8F-important-notice-upcoming-changes-to-the-bitnami-catalog), to pin the rabbitmq image.