### PR TITLE
feat: add cert manager support to ingress

### DIFF
--- a/deployment/chart/templates/ingress.yaml
+++ b/deployment/chart/templates/ingress.yaml
@@ -8,9 +8,17 @@ metadata:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     # https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#custom-max-body-size
     nginx.ingress.kubernetes.io/proxy-body-size: "20m"
+    cert-manager.io/issuer: letsencrypt-prod
 spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - intersect.nationalsciencedatafabric.org
+    secretName: intersect-dashboard-tls
   rules:
   - host: intersect.nationalsciencedatafabric.org
     http:


### PR DESCRIPTION
This PR adds https support for the ingress. This adds the necessary annotations and specs to the ingress for further deployments. Closes #32 

# Cert-manager 

[cert-manager](https://cert-manager.io/) was deployed into the cluster. Tested letsencrypt staging issuer CRD, and then deployed the production issuer, it generated the certificate correctly.

## Implementation Notes

- Since **v1.18** of cert-manager the ACME http01 challenge paths use `pathType: exact` [documented here](https://cert-manager.io/docs/releases/release-notes/release-notes-1.18/#acme-http01-challenge-paths-now-use-pathtype-exact-in-ingress-routes), this will cause it to break since we use `pathType: ImplementationSpecific` and is currently has a bug with the nginx controller version we have.

- I applied the helm chart for cert-manager with values from [option 1](https://cert-manager.io/docs/releases/release-notes/release-notes-1.18/#option-1-disable-the-acmehttp01ingresspathtypeexact-feature-in-cert-manager) to fix it.

- [https://intersect.nationalsciencedatafabric.org/dashboard](https://intersect.nationalsciencedatafabric.org/dashboard) now has TLS cert.

- A few CRDs have been applied namely the Issuers for letsencrypt both staging and prod.

## Other

I've been looking into [Argo](https://argo-cd.readthedocs.io/en/stable/) for CD. It can be good considering there are quite a few CRDs now applied and helm charts that bootstrap the cluster.
