### PR TITLE
ci: add DIAL helm chart to CI deployment

### DIFF
--- a/.github/workflows/deploy-linode.yml
+++ b/.github/workflows/deploy-linode.yml
@@ -21,6 +21,7 @@ jobs:
           mkdir -p ~/.kube
           echo ${{ secrets.LINODE_B64_KUBECONFIG }} | base64 --decode > ~/.kube/config
           echo ${{ secrets.LINODE_B64_SECRET_VALUES }} | base64 --decode > ~/.kube/secret-values.yaml
+          echo ${{ secrets.LINODE_B64_DIAL_VALUES }} | base64 --decode > ~/.kube/dial-values.yaml
           chmod -R g-r ~/.kube/
 
       - name: Install Helm
@@ -30,9 +31,12 @@ jobs:
       - name: Add Helm repo dependencies
         run: |
           helm dependency update deployment/chart
+          helm dependency update deployment/dial
 
       - name: Deploy on Linode
-        run: helm upgrade -n intersect nsdf-intersect deployment/chart --install --force --wait -f ~/.kube/secret-values.yaml
+        run: |
+          helm upgrade -n intersect nsdf-intersect deployment/chart --install --force --wait -f ~/.kube/secret-values.yaml
+          helm upgrade -n dial dial deployment/dial --install --force --wait -f ~/.kube/dial-values.yaml
 
       - name: Cleanup
         run: rm -rf ~/.kube

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -12,14 +12,17 @@ These are stored as Github secrets.
 
 - `LINODE_B64_KUBECONFIG` - base64-encoded Kubeconfig for the Kubernetes cluster
 - `LINODE_B64_SECRET_VALUES` - base64-encoded secret values we apply additionally to the deployment
-
+- `LINODE_B64_DIAL_VALUES` - base64-encoded secret values to apply to the Dial chart deployment
 
 ### Secrets values yaml file
 
-To update `LINODE_B64_SECRET_VALUES`, use `examples.secrets-values.yaml` as a template for new yaml (say `new-secrets.yaml`) and...
-  1. Update the passwords secrets where `CHANGEME` occurs
-    - To create random, you can use: `python -c "import secrets; print(secrets.token_urlsafe())"`
-  2. Base64 encode the yaml file: `base64 new-secret.yaml`
-  3. Update the GitHub Actions `LINODE_B64_SECRET_VALUES` with this encoded string from step (2):
-    - link: https://github.com/nsdf-fabric/NSDF-INTERSECT/settings/secrets/actions
-  4. Save changes!
+To update `LINODE_B64_SECRET_VALUES` or `LINODE_B64_DIAL_VALUES`, use `examples.secrets-values.yaml` or `dial-example.secret-values.yaml` respectively, as a template for new yaml (say `new-secrets.yaml`) and...
+
+1. Update the passwords secrets where `CHANGEME` occurs
+   - To create random, you can use: `python -c "import secrets; print(secrets.token_urlsafe())"`
+
+2. Base64 encode the yaml file: `base64 new-secret.yaml`
+3. Update the GitHub Actions `LINODE_B64_SECRET_VALUES`/`LINODE_B64_DIAL_VALUES` with this encoded string from step (2):
+   - link: https://github.com/nsdf-fabric/NSDF-INTERSECT/settings/secrets/actions
+
+4. Save changes!

--- a/deployment/dial-example.secret-values.yaml
+++ b/deployment/dial-example.secret-values.yaml
@@ -1,0 +1,45 @@
+dial:
+  dial:
+    image:
+      registry: ghcr.io
+      repository: "intersect-dial/dial"
+      tag: "main"
+
+    configFile: |
+      {
+        "intersect": {
+          "brokers": [
+            {
+              "username": "",
+              "password": "",
+              "host": "",
+              "port": 123,
+              "protocol": "mqtt3.1.1"
+            }
+          ]
+        },
+        "intersect-hierarchy": {
+          "organization": "",
+          "facility": "",
+          "system": "",
+          "subsystem": "",
+          "service": ""
+        },
+        "dial": {
+          "mongo": {
+            "username": "",
+            "password": "",
+            "host": "",
+            "port": 123
+          }
+        }
+      }
+
+  mongodb:
+    enabled: true
+    auth:
+      enabled: true
+      username: user
+      password: ""
+      rootPassword: ""
+      database: mydb

--- a/deployment/dial/Chart.yaml
+++ b/deployment/dial/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: dial-intersect-linode
+description: Deployment of Dial for our Linode instance
+type: application
+version: 0.0.1
+dependencies:
+  # Dial service
+  - name: dial
+    repository: https://intersect-dial.github.io/dial/
+    version: 0.1.0


### PR DESCRIPTION
This PR adds automatic deployment of the [DIAL Helm chart](https://github.com/INTERSECT-DIAL/dial/tree/develop/charts/dial) into the NSDF k8s cluster.

* Created the `LINODE_B64_DIAL_VALUES` secret to pass into as values to the chart
* Adds the helm commands to the github deploy action
* Adds the `dial` chart under `deployment`
* Example of values as `dial-example.secret-values.yaml`